### PR TITLE
Bump version to 1.0.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digital-clock",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "author": "Levente Tóth",
   "scripts": {


### PR DESCRIPTION
This pull request includes a version update for the `digital-clock` package.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `0.0.0` to `1.0.0`.